### PR TITLE
Add description to composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This bundle provides an easy way to protect your project by limiting access to y
 
 ## Install the bundle
 ```bash
-composer require bedrock/rate-limit-bundle
+composer require bedrockstreaming/rate-limit-bundle
 ```
 
 Update your _config/bundles.php_ file to add the bundle for all env

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
-    "name": "bedrock/rate-limit-bundle",
+    "name": "bedrockstreaming/rate-limit-bundle",
+    "description": "Manage rate limitation for your routes",
     "type": "symfony-bundle",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Add `description` field to composer.json.

This information seems required to be found in packagist.org

We need to update vendor name, because bedrock is already used in packagist :sadpanda: