### PR TITLE
feat(behaviour): change the behaviour of the bundle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BedrockStreaming/api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,6 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: 7.4
+                  tools: composer:v2
             - run: make install
             - run: make ci

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you switch `debug` to true, a more detailed response will be displayed. This 
 ### How to know if rate limit is reached
 The bundle will add 4 headers to the response :
 * `x-rate-limit` : display how many hits can made until the limit is reached
-* `x-rate-limit-hits` : display how many hits has been done until the beginning of the period 
+* `x-rate-limit-hits` : display how many hits has been done since the beginning of the period 
 * `x-rate-limit-until` : display the date of the end of the limit in ISO 8601 format  
 * `retry-after` : display how many remaining seconds the limit is applied
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bedrock_rate_limit:
     limit: 25 # 1000 requests by default
     period: 600 # 60 seconds by default
     limit_by_route: true|false # false by default
-    display_headers: true|false # false by default
+    debug: true|false # false by default
 ```
 By default, the limitation is common to all routes annotated `@RateLimit()`. 
 For example, if you keep the default configuration and you configure the `@RateLimit()` annotation in 2 routes. Limit will shared between this 2 routes, if user consume all authorized calls on the first route, the second route couldn't be called.
@@ -33,9 +33,15 @@ If you swicth `limit_by_route` to true, users will be allowed to reach the limit
 `@GraphQLRateLimit()`annotation allows you to rate limit by graphQL query or mutation.
 /!\ To use this annotation, you will need to install suggested package.
 
-If you switch `display_headers` to true, 3 headers will be added `x-rate-limit`, `x-rate-limit-hits`, `x-rate-limit-untils` to your responses. This can be usefull to debug your limitations.
-`display_headers` is used to display a verbose return if limit is reached.
- 
+If you switch `debug` to true, a more detailed response will be displayed. This can be usefull to debug your limitations. Do not use this in prod environment.
+
+### How to know if rate limit is reached
+The bundle will add 4 headers to the response :
+* `x-rate-limit` : display how many hits can made until the limit is reached
+* `x-rate-limit-hits` : display how many hits has been done until the beginning of the period 
+* `x-rate-limit-until` : display the date of the end of the limit in ISO 8601 format  
+* `retry-after` : display how many remaining seconds the limit is applied
+
 ### Configure your storage 
 You must tell Symfony which storage implementation you want to use.
 

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "symfony/event-dispatcher": "4.4.*|^5.0",
         "symfony/http-foundation": "4.4.*|^5.0",
         "symfony/http-kernel": "4.4.*|^5.0",
-        "symfony/options-resolver": "4.4.*|^5.0"
+        "symfony/options-resolver": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.5.13",
+        "phpunit/phpunit": "9.5.*",
         "m6web/php-cs-fixer-config": "1.3.*",
         "phpstan/phpstan": "1.4.3",
         "phpstan/phpstan-phpunit": "1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,15 @@
         "symfony/event-dispatcher": "4.4.*|^5.0",
         "symfony/http-foundation": "4.4.*|^5.0",
         "symfony/http-kernel": "4.4.*|^5.0",
-        "symfony/options-resolver": "^5.0"
+        "symfony/options-resolver": "4.4.*|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.4.*",
+        "phpunit/phpunit": "9.5.13",
         "m6web/php-cs-fixer-config": "1.3.*",
-        "phpstan/phpstan": "0.12.*",
-        "phpstan/phpstan-phpunit": "0.12.*",
-        "symfony/var-dumper": "4.4.*"
+        "phpstan/phpstan": "1.4.3",
+        "phpstan/phpstan-phpunit": "1.0.0",
+        "symfony/var-dumper": "4.4.*",
+        "phpstan/phpstan-symfony":"1.1.2"
     },
     "suggest": {
         "webonyx/graphql-php": "Needed to support @GraphQLRateLimit annotation"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,12 +1,13 @@
 includes:
     - 'vendor/phpstan/phpstan-phpunit/extension.neon'
     - 'vendor/phpstan/phpstan-phpunit/rules.neon'
+    - 'vendor/phpstan/phpstan-symfony/extension.neon'
+    - 'vendor/phpstan/phpstan-symfony/rules.neon'
 
 parameters:
     paths:
         - 'src'
         - 'tests'
     level: 'max'
-    checkGenericClassInNonGenericObjectType: false
-    ignoreErrors:
-        - '#Cannot call method integerNode\(\) on Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface\|null\.#'
+    checkGenericClassInNonGenericObjectType: true
+    checkMissingIterableValueType:           true

--- a/src/DependencyInjection/BedrockRateLimitExtension.php
+++ b/src/DependencyInjection/BedrockRateLimitExtension.php
@@ -30,7 +30,7 @@ class BedrockRateLimitExtension extends Extension
         $container->setParameter('bedrock_rate_limit.limit', $config['limit']);
         $container->setParameter('bedrock_rate_limit.period', $config['period']);
         $container->setParameter('bedrock_rate_limit.limit_by_route', $config['limit_by_route']);
-        $container->setParameter('bedrock_rate_limit.display_headers', $config['display_headers']);
+        $container->setParameter('bedrock_rate_limit.debug', $config['debug']);
 
         $loader = new YamlFileLoader(
             $container,

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue(60)
                     ->min(0)
                 ->end()
-                ->booleanNode('display_headers')
+                ->booleanNode('debug')
                     ->defaultValue(false)
                 ->end()
             ->end()

--- a/src/EventListener/ReadRateLimitAnnotationListener.php
+++ b/src/EventListener/ReadRateLimitAnnotationListener.php
@@ -78,7 +78,7 @@ class ReadRateLimitAnnotationListener implements EventSubscriberInterface
                 $annotation->getPeriod() ?? $this->period
             );
 
-            $rateLimit->varyHashOn('_route', $request->attributes->get('_route'));
+            $rateLimit->varyHashOn('_route', strval($request->attributes->get('_route')));
         }
 
         foreach ($this->rateLimitModifiers as $hashKeyVarier) {

--- a/src/Model/StoredRateLimit.php
+++ b/src/Model/StoredRateLimit.php
@@ -63,7 +63,9 @@ class StoredRateLimit
             ),
             'limit' => $this->getLimit(),
             'period' => $this->rateLimit->getPeriod(),
-            'until' => $this->getValidUntil()->format('Y-m-d H:i:s'),
+            'until' => $this->getValidUntil()
+                ->setTimezone(new \DateTimeZone(date_default_timezone_get()))
+                ->format('c'),
             'vary' => $this->rateLimit->getDiscriminator(),
         ];
     }

--- a/src/RateLimitModifier/RequestAttributeRateLimitModifier.php
+++ b/src/RateLimitModifier/RequestAttributeRateLimitModifier.php
@@ -21,6 +21,6 @@ class RequestAttributeRateLimitModifier implements RateLimitModifierInterface
 
     public function modifyRateLimit(Request $request, RateLimit $rateLimit): void
     {
-        $rateLimit->varyHashOn($this->attributeName, $request->attributes->get($this->attributeName));
+        $rateLimit->varyHashOn($this->attributeName, strval($request->attributes->get($this->attributeName)));
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -21,8 +21,4 @@ services:
 
   Bedrock\Bundle\RateLimitBundle\EventListener\LimitRateListener:
     arguments:
-      $displayHeaders: '%bedrock_rate_limit.display_headers%'
-
-  Bedrock\Bundle\RateLimitBundle\EventListener\AddRateLimitHeadersListener:
-    arguments:
-      $displayHeaders: '%bedrock_rate_limit.display_headers%'
+      $debug: '%bedrock_rate_limit.debug%'

--- a/tests/EventListener/AddRateLimitHeadersListenerTest.php
+++ b/tests/EventListener/AddRateLimitHeadersListenerTest.php
@@ -15,18 +15,19 @@ class AddRateLimitHeadersListenerTest extends TestCase
 {
     public function testItDoesNotSetHeadersIfNoRateLimitProvidedInRequest(): void
     {
-        $addRateLimitHeadersListener = new AddRateLimitHeadersListener(true);
+        $addRateLimitHeadersListener = new AddRateLimitHeadersListener();
         $addRateLimitHeadersListener->onKernelResponse($event = $this->createEvent());
 
         $response = $event->getResponse();
         $this->assertFalse($response->headers->has('x-rate-limit'));
         $this->assertFalse($response->headers->has('x-rate-limit-hits'));
         $this->assertFalse($response->headers->has('x-rate-limit-until'));
+        $this->assertFalse($response->headers->has('retry-after'));
     }
 
     public function testItSetsHeadersIfRateLimitProvidedInRequest(): void
     {
-        $addRateLimitHeadersListener = new AddRateLimitHeadersListener(true);
+        $addRateLimitHeadersListener = new AddRateLimitHeadersListener();
         $addRateLimitHeadersListener->onKernelResponse(
             $event = $this->createEvent(
                 new Request(
@@ -45,29 +46,7 @@ class AddRateLimitHeadersListenerTest extends TestCase
         $this->assertSame(1000, (int) $response->headers->get('x-rate-limit'));
         $this->assertSame(4, (int) $response->headers->get('x-rate-limit-hits'));
         $this->assertSame($validUntil->format('c'), $response->headers->get('x-rate-limit-until'));
-    }
-
-    public function testResponseHasNotHeaderIfDisplayHeadersIsDisable(): void
-    {
-        $addRateLimitHeadersListener = new AddRateLimitHeadersListener(false);
-        $addRateLimitHeadersListener->onKernelResponse(
-            $event = $this->createEvent(
-                new Request(
-                    [],
-                    [],
-                    [
-                        '_stored_rate_limit' => new StoredRateLimit(
-                            new RateLimit(1000, 60), 4, $validUntil = new \DateTimeImmutable()
-                        ),
-                    ]
-                )
-            )
-        );
-
-        $response = $event->getResponse();
-        $this->assertFalse($response->headers->has('x-rate-limit'));
-        $this->assertFalse($response->headers->has('x-rate-limit-hits'));
-        $this->assertFalse($response->headers->has('x-rate-limit-until'));
+        $this->assertSame('0', $response->headers->get('retry-after'));
     }
 
     private function createEvent(Request $request = null): ResponseEvent

--- a/tests/EventListener/LimitRateListenerWithManuallyResetableRateLimitStorageInterfaceTest.php
+++ b/tests/EventListener/LimitRateListenerWithManuallyResetableRateLimitStorageInterfaceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bedrock\Bundle\RateLimitBundle\Tests\EventListener;
 
 use Bedrock\Bundle\RateLimitBundle\EventListener\LimitRateListener;
+use Bedrock\Bundle\RateLimitBundle\Model\RateLimit;
 use Bedrock\Bundle\RateLimitBundle\Model\StoredRateLimit;
 use Bedrock\Bundle\RateLimitBundle\Storage\ManuallyResetableRateLimitStorageInterface;
 
@@ -25,6 +26,7 @@ class LimitRateListenerWithManuallyResetableRateLimitStorageInterfaceTest extend
     public function testItResetsAndStoresNewRateLimitIfCurrentOneIsOutdated(): void
     {
         $event = $this->createEventWithRateLimitInRequest();
+        /** @var RateLimit $rateLimit */
         $rateLimit = $event->getRequest()->attributes->get('_rate_limit');
 
         $this->storage->expects($this->once())

--- a/tests/Model/StoredRateLimitTest.php
+++ b/tests/Model/StoredRateLimitTest.php
@@ -39,7 +39,7 @@ class StoredRateLimitTest extends TestCase
                 'message' => 'Too many requests. Only 1000 calls allowed every 60 seconds.',
                 'limit' => 1000,
                 'period' => 60,
-                'until' => '2020-06-01 00:00:00',
+                'until' => '2020-06-01T00:00:00+00:00',
                 'vary' => '{"http_method":"GET","customer":"customer-test"}',
             ],
             $storedRateLimit->getLimitReachedOutput()


### PR DESCRIPTION
## Why?
⚠️ BC Break ⚠️ 
1 . Display all date with timezone
2. Always display headers
3. Add `retry-after` header to display how many remaining seconds the limit is applied (rfc from Mozilla ([here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)) and symfony based his retryable client on this header ([here](https://github.com/symfony/http-client/blob/5.4/RetryableHttpClient.php#L137-L150)))
4. Change body response to integrate an api+json/problem response
```
{
    "status": 429,
    "code": "too-many-requests",
    "title": "Too Many Requests"
}
```

## How?
Remove attribute `display_headers` in the config file and add a `debug` attribute to display more informations in the body response (use it in non production env)
