### PR TITLE
fix(di): fix missing container injection from Sf6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BedrockStreaming/api

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,34 +2,14 @@ services:
   _defaults:
     autowire: true
     autoconfigure: true
+    bind:
+        Symfony\Component\DependencyInjection\ContainerInterface $container: '@service_container'
+        int $limit: '%bedrock_rate_limit.limit%'
+        int $period: '%bedrock_rate_limit.period%'
+        array $routes: '%bedrock_rate_limit.routes%'
+        bool $limitByRoute: '%bedrock_rate_limit.limit_by_route%'
+        bool $displayHeaders: '%bedrock_rate_limit.display_headers%'
+        iterable $rateLimitModifiers: !tagged rate_limit.modifiers
 
   Bedrock\Bundle\RateLimitBundle\:
     resource: '../../../src/*'
-
-  Bedrock\Bundle\RateLimitBundle\EventListener\ReadRateLimitAttributeListener:
-    arguments:
-      $limit: '%bedrock_rate_limit.limit%'
-      $period: '%bedrock_rate_limit.period%'
-      $limitByRoute: '%bedrock_rate_limit.limit_by_route%'
-      $rateLimitModifiers: !tagged rate_limit.modifiers
-
-  Bedrock\Bundle\RateLimitBundle\EventListener\ReadRateLimitConfigurationListener:
-    arguments:
-      $limit: '%bedrock_rate_limit.limit%'
-      $period: '%bedrock_rate_limit.period%'
-      $rateLimitModifiers: !tagged rate_limit.modifiers
-      $routes: '%bedrock_rate_limit.routes%'
-
-  Bedrock\Bundle\RateLimitBundle\EventListener\ReadGraphQLRateLimitAttributeListener:
-    arguments:
-      $limit: '%bedrock_rate_limit.limit%'
-      $period: '%bedrock_rate_limit.period%'
-      $rateLimitModifiers: !tagged rate_limit.modifiers
-
-  Bedrock\Bundle\RateLimitBundle\EventListener\LimitRateListener:
-    arguments:
-      $displayHeaders: '%bedrock_rate_limit.display_headers%'
-
-  Bedrock\Bundle\RateLimitBundle\EventListener\AddRateLimitHeadersListener:
-    arguments:
-      $displayHeaders: '%bedrock_rate_limit.display_headers%'


### PR DESCRIPTION
## Description

It seems that from Symfony 6 (maybe 5), the container is not injected by default, leading to this kind of error

```bash
$ ./bin/console c:c 

In DefinitionErrorExceptionPass.php line 54:
                                                                                                                                                                                                                                        
  Cannot autowire service "Bedrock\Bundle\RateLimitBundle\EventListener\ReadGraphQLRateLimitAttributeListener": argument "$container" of method "__construct()" references interface "Symfony\Component\DependencyInjection\ContainerI  
  nterface" but no such service exists. You should maybe alias this interface to the existing "service_container" service.                                                                                                              
                                                                                                                                                                                                                                        
```

We can force the injection of the full container for our services. Maybe I could have made a service locator from controllers, but I would have missed real service IDs. Feel free to propose a better solution.

Also I've refactored used parameters with bindings, so the configuration is simpler.