### PR TITLE
feat: add symfo54-backward-compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                version: [ '8.0', '8.1' ]
+                php-version: [ '8.0', '8.1' ]
+                symfony-version: ['^5.4', '^6.0']
             fail-fast: false
         steps:
             - uses: actions/checkout@master
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.version }}
+                  php-version: ${{ matrix.php-version }}
+            - run: composer require symfony/symfony:${{ matrix.symfony-version }} --no-update
             - run: make install
             - run: make ci

--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
     "require": {
         "php": ">=8.0",
         "ext-json": "*",
-        "symfony/config": "^6.0",
-        "symfony/dependency-injection": "^6.0",
-        "symfony/event-dispatcher": "^6.0",
-        "symfony/http-foundation": "^6.0",
-        "symfony/http-kernel": "^6.0",
-        "symfony/options-resolver": "^6.0"
+        "symfony/config": "^5.4 || ^6.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0",
+        "symfony/event-dispatcher": "^5.4 || ^6.0",
+        "symfony/http-foundation": "^5.4 || ^6.0",
+        "symfony/http-kernel": "^5.4 || ^6.0",
+        "symfony/options-resolver": "^5.4 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "9.5.*",
         "m6web/php-cs-fixer-config": "^2.1",
         "phpstan/phpstan": "^1.5",
         "phpstan/phpstan-phpunit": "^1.1",
-        "symfony/var-dumper": "^6.0",
+        "symfony/var-dumper": "^5.4 || ^6.0",
         "rector/rector": "^0.12.22"
     },
     "suggest": {


### PR DESCRIPTION
## Why?
I need to use this bundle into a project that requires PHP 8 and Symfony 5.4

## How?
- Add symfony ^5.4 support and keep ^6.0
- Change the gha test workflows to include tests of multiple versions of Symfony